### PR TITLE
Fix Makefile workflow

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,4 +18,4 @@ jobs:
       run: make install
 
     - name: Run check
-      run: make all
+      run: make -B all


### PR DESCRIPTION
Run make check with the -B flag so that it builds regardless of the existence of the PNG file.